### PR TITLE
FOUR-12692: C# - Lua Executors Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
-RUN apt update
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list \
+    && apt update
 
 # Copy over our .NET C# solution skeleton
 COPY ./src /opt/executor


### PR DESCRIPTION
## Issue
It is not possible to install or rebuild the Docker Executor C# image.

## Solution
- The solution implemented addresses an issue with Debian Stretch repositories that have been archived and therefore, are no longer available or maintained.

**Recommendation**:
Although this solution addresses the immediate problem, it is highly recommended to consider upgrading to a more recent base image.

## How to test
- Click on "Save and rebuild" on `/admin/script-executors`.

## Related ticket
- [FOUR-12692](https://processmaker.atlassian.net/browse/FOUR-12692)

[FOUR-12692]: https://processmaker.atlassian.net/browse/FOUR-12692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ